### PR TITLE
scopePopularAllTime and scopePopularBetween modification

### DIFF
--- a/src/Concerns/FilterByPopularityTimeFrame.php
+++ b/src/Concerns/FilterByPopularityTimeFrame.php
@@ -30,7 +30,8 @@ trait FilterByPopularityTimeFrame
      */
     public function scopePopularAllTime(Builder $builder): Builder
     {
-        return $builder->withTotalVisitCount()
+        return $builder->whereHas('visits')
+                        ->withTotalVisitCount()
                         ->orderBy('visit_count_total', 'desc');
     }
 

--- a/src/Concerns/FilterByPopularityTimeFrame.php
+++ b/src/Concerns/FilterByPopularityTimeFrame.php
@@ -160,7 +160,7 @@ trait FilterByPopularityTimeFrame
         return $builder->whereHas('visits', $this->betweenScope($from, $to))
                         ->withCount([
                             'visits as visit_count_total' => $this->betweenScope($from, $to),
-                        ]);
+                        ])->orderBy('visit_count_total', 'desc');
     }
 
     /**


### PR DESCRIPTION
1. Inside the scopePopularAllTime() I added a whereHas('visits) to only fetch records that has been visited, initially it was returning all records including those without visits.
2. Inside the scopePopularBetween(), I added an orderBy clause to get the records in descending order starting with that with the highest visit count. This is helpful in case the user only needs one result that has highest visit count.