### PR TITLE
Adding Allow Plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,13 @@
         "test-coverage": "vendor/bin/pest --coverage"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "phpstan/extension-installer": true,
+            "phpstan/phpstan-deprecation-rules": true,
+            "phpstan/phpstan-phpunit": true,
+            "phpunit/phpunit": true
+        }
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -55,8 +55,7 @@
             "pestphp/pest-plugin": true,
             "phpstan/extension-installer": true,
             "phpstan/phpstan-deprecation-rules": true,
-            "phpstan/phpstan-phpunit": true,
-            "phpunit/phpunit": true
+            "phpstan/phpstan-phpunit": true
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -51,10 +51,8 @@
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-            "phpstan/extension-installer": true,
-            "phpstan/phpstan-deprecation-rules": true,
-            "phpstan/phpstan-phpunit": true,
-            "phpunit/phpunit": true
+            "pestphp/pest-plugin-laravel": true,
+            "pestphp/pest-plugin": true
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,11 @@
         "sort-packages": true,
         "allow-plugins": {
             "pestphp/pest-plugin-laravel": true,
-            "pestphp/pest-plugin": true
+            "pestphp/pest-plugin": true,
+            "phpstan/extension-installer": true,
+            "phpstan/phpstan-deprecation-rules": true,
+            "phpstan/phpstan-phpunit": true,
+            "phpunit/phpunit": true
         }
     },
     "extra": {


### PR DESCRIPTION
Adding `allow-plugins` into `composer.json` to prevent the tests fails