### PR TITLE
add hits to visits

### DIFF
--- a/src/Models/Visit.php
+++ b/src/Models/Visit.php
@@ -54,4 +54,21 @@ class Visit extends Model implements CanPresent
     {
         return $this->morphTo();
     }
+
+    public function resetHits()
+    {
+        $this->fill(['data->hits' => 1]);
+        $this->save();
+    }
+
+    public function incrementHits()
+    {
+        $this->fill(['data->hits' => $this->hits + 1]);
+        $this->save();
+    }
+
+    public function getHitsAttribute()
+    {
+        return is_numeric($this->data['hits'] ?? null) ? $this->data['hits'] : 1;
+    }
 }

--- a/src/PendingVisit.php
+++ b/src/PendingVisit.php
@@ -135,13 +135,18 @@ class PendingVisit
             ->visits()
             ->latest()
             ->firstOrCreate($this->buildJsonColumns(), [
-                'data' => $this->attributes,
+                'data' => array_merge($this->attributes, ['hits' => 1]),
             ]);
 
+        if($this->shouldBeLoggedAgain($visit)){
+            $visit->replicate()->resetHits();
+            return;
+        }
+
         $visit->when(
-            $this->shouldBeLoggedAgain($visit),
+            !$visit->wasRecentlyCreated,
             function () use ($visit) {
-                $visit->replicate()->save();
+                $visit->incrementHits();
             }
         );
     }

--- a/tests/Feature/Visits/VisitsTest.php
+++ b/tests/Feature/Visits/VisitsTest.php
@@ -131,7 +131,7 @@ it('gets the associated user when creating a visit', function () {
         ->toEqual($user->name);
 });
 
-it('does note create duplicate visits with the same data', function () {
+it('does note create duplicate visits with the same data, but increments hits', function () {
     $post = Post::factory()->create();
 
     $post->visit()->withData([
@@ -143,9 +143,10 @@ it('does note create duplicate visits with the same data', function () {
     ]);
 
     expect($post->visits->first()->count())->toBe(1);
+    expect($post->visits->sum('hits'))->toBe(2);
 });
 
-it('does not create visits within the same time frame', function () {
+it('does not create visits within the same time frame, but increments hits', function () {
     $post = Post::factory()->create();
 
     Carbon::setTestNow(now()->subDays(2));
@@ -158,6 +159,7 @@ it('does not create visits within the same time frame', function () {
     $post->visit();
 
     expect($post->visits->first()->count())->toBe(2);
+    expect($post->visits->sum('hits'))->toBe(3);
 });
 
 it('creates visits after an hourly time frame', function () {


### PR DESCRIPTION
Add hits to visits to really know how many pages renders have your app

I'ts necesary cause when many people use the same IP (ex: hotel) you only get 1 visit for all on the given interval, with this you can have the visits (ip based) and hits (all)