### PR TITLE
Optimize New Visit Creation.

### DIFF
--- a/src/PendingVisit.php
+++ b/src/PendingVisit.php
@@ -133,6 +133,7 @@ class PendingVisit
         // @phpstan-ignore-next-line
         $visit = $this->model
             ->visits()
+            ->where('created_at', '>=', $this->interval)
             ->latest()
             ->firstOrCreate($this->buildJsonColumns(), [
                 'data' => $this->attributes,


### PR DESCRIPTION
We run into optimisation problem, when new visit creation took around 5000ms.
Solution for this, is not to go thru whole table, but only look if there is a visit in given interval.