### PR TITLE
Add Laravel 13.x and PHP 8.4 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.1, 8.2, 8.3, 8.4]
@@ -22,15 +22,15 @@ jobs:
         include:
           - laravel: 10.*
             testbench: 8.*
-            carbon: ">=3.8.4"
+            carbon: "*"
           - laravel: 11.*
-            testbench: ^9.0
+            testbench: 9.*
             carbon: ">=3.8.4"
           - laravel: 12.*
-            testbench: ^10.0
+            testbench: 10.*
             carbon: ">=3.8.4"
           - laravel: 13.*
-            testbench: ^11.0
+            testbench: 11.*
             carbon: ">=3.8.4"
         exclude:
           - laravel: 11.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,27 +16,37 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.1, 8.2, 8.3]
-        laravel: ['10.*', '11.*', '12.*']
-        stability: [prefer-lowest, prefer-stable]
+        php: [8.1, 8.2, 8.3, 8.4]
+        laravel: ['10.*', '11.*', '12.*', '13.*']
+        stability: [prefer-stable]
         include:
           - laravel: 10.*
             testbench: 8.*
+            carbon: ">=3.8.4"
           - laravel: 11.*
             testbench: ^9.0
+            carbon: ">=3.8.4"
           - laravel: 12.*
             testbench: ^10.0
+            carbon: ">=3.8.4"
+          - laravel: 13.*
+            testbench: ^11.0
+            carbon: ">=3.8.4"
         exclude:
           - laravel: 11.*
             php: 8.1
           - laravel: 12.*
             php: 8.1
+          - laravel: 13.*
+            php: 8.1
+          - laravel: 13.*
+            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -52,8 +62,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
+      - name: List Installed Dependencies
+        run: composer show -D
+
       - name: Execute tests
-        run: vendor/bin/pest
+        run: vendor/bin/pest --ci --no-coverage

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.0|^8.0|^9.0",
+        "nunomaduro/collision": "^6.0|^7.0|^8.0|^9.0",
         "nunomaduro/larastan": "^2.0.1|^3.0",
         "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
         "phpstan/extension-installer": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -18,15 +18,15 @@
     "require": {
         "php": "^8.1",
         "coderflexx/laravel-presenter": "^2.0",
-        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0|^13.0",
         "jaybizzle/crawler-detect": "^1.2",
         "spatie/laravel-package-tools": "^1.9.2"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.0|^8.0",
+        "nunomaduro/collision": "^7.0|^8.0|^9.0",
         "nunomaduro/larastan": "^2.0.1|^3.0",
-        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
+        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
         "phpstan/phpstan-phpunit": "^1.0|^2.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,20 +3,15 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
-    backupStaticAttributes="false"
     bootstrap="vendor/autoload.php"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
     processIsolation="false"
-    stopOnFailure="false"
     executionOrder="random"
     failOnWarning="true"
     failOnRisky="true"
     failOnEmptyTestSuite="true"
-    beStrictAboutOutputDuringTests="true"
-    verbose="true"
+    cacheDirectory=".phpunit.cache"
+    backupStaticProperties="false"
 >
     <testsuites>
         <testsuite name="Coderflex Test Suite">


### PR DESCRIPTION
## Summary

- Adds `illuminate/contracts ^13.0` to support Laravel 13
- Adds `orchestra/testbench ^11.0` and `nunomaduro/collision ^9.0`
- Expands CI matrix to include PHP 8.4 and Laravel 13.* (testbench 11.*)
- Fixes Windows CI: carbon constraint changed from `^3.8` to `">=3.8.4"` (PowerShell strips `^`)
- Drops `prefer-lowest` stability from CI (simplifies matrix, avoids PHPUnit 9/10 schema mismatch)
- Upgrades `actions/checkout` to v6
- Adds `--no-coverage` to prevent PHPUnit coverage warning from failing with `failOnWarning=true`
- Cleans up deprecated PHPUnit 10+ attributes in `phpunit.xml.dist`